### PR TITLE
fixed broken link

### DIFF
--- a/md_files/side_foodcompat_js.md
+++ b/md_files/side_foodcompat_js.md
@@ -9,7 +9,7 @@ title: Side Project - iCloud Control Script
 
 **THIS PROJECT IS ONGOING. PAGE UNDER CONSTRUCTION.**
 
-This project is similar to [the Python project here](/md_files/side_foodcompat/). It is not yet known if this project is do-able. As such, this page may be deleted as necessary.
+This project is similar to [the Python project here](/md_files/side_foodcompat). It is not yet known if this project is do-able. As such, this page may be deleted as necessary.
 
 <!-- ## Side Project Work Repository -->
 


### PR DESCRIPTION
apparently an extra slash "/" is all it takes to get a broken link. Offline tests are okay, but once deployed as a GitHub page it fails.